### PR TITLE
December 1 update

### DIFF
--- a/Symfony/src/Codebender/ApiBundle/Controller/DefaultController.php
+++ b/Symfony/src/Codebender/ApiBundle/Controller/DefaultController.php
@@ -125,8 +125,13 @@ class DefaultController extends Controller
 
                 if ($data["success"]) {
                     $fetchedLibs[] = $header;
+                    $files_to_add = array();
+                    foreach ($data["files"] as $file){
+                        if (in_array(pathinfo($file['filename'], PATHINFO_EXTENSION), array('cpp', 'h', 'c', 'S', 'inc')))
+                            $files_to_add[] = $file;
+                    }
 
-                    $libraries[$header] = $data["files"];
+                    $libraries[$header] = $files_to_add;
                     $foundHeaders[] = $header . ".h";
 
                 } elseif (!$data['success']){


### PR DESCRIPTION
From now on, the library manager also sends non-code files, like pdf or jpg files. So the builder has to send only files that are needed by the compiler. 
