### PR TITLE
JSON responses on builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     # eratosthenes library management system url (encrypted) --> LIBRARY_URL
     - secure: "DX1KR4VH1AwthSZ/6me6y8EB/xCf7kH+hXyacOiIwHmxPe7xR/+v7nht1Dlspco0nonv7hlF8yCilF2f3cIMHQlmyg9s1kuVZ4QtC8O9+ZkVQ6fDhhH7HKYNUKjhKO7eT5a+RD7YCXQYQSfDfJ35cWeK3vAast3zWK2pnmdKXhc="
     # codebender compiler url (encrypted) --> COMPILER_URL
-    - secure: "QUYKE9qjXxeCWZPl+CQpIvj3J9Bz9aVu9jo1m+EDjaQ3gXwQ+kXTyZ68eDeLLCFq8s5IEcsNdE6X7wyBh+eu6rzEU5EwvGMqPdIpXxnhkzTbb8d2KRCScwkglrB/Dbh1Ovhq0+CdaSkLSQBQvOuxkqgGNf1Oophws6eG4iCIZKQ="’’
+    - secure: "QUYKE9qjXxeCWZPl+CQpIvj3J9Bz9aVu9jo1m+EDjaQ3gXwQ+kXTyZ68eDeLLCFq8s5IEcsNdE6X7wyBh+eu6rzEU5EwvGMqPdIpXxnhkzTbb8d2KRCScwkglrB/Dbh1Ovhq0+CdaSkLSQBQvOuxkqgGNf1Oophws6eG4iCIZKQ="
 
 before_script:
   - sudo chmod +x scripts/travis_install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ php:
 
 env:
   global:
-    # eratosthenes library management system url (encrypted)
-    - secure: "ZYn4o229W7hq1uzj/Tii9h/a3iJlr9Li4TBaTNFXm6JY2H49lA57L1DIFUaTleTUx2Ibs2+kUrV3NFQ9Mo/ThO67gV5Q1XEMjxgFzAKt4AuWJ5TNbHxs3GBTjYc+129QCKSd0WdzrRDqEC2nZ9GjI+j7lS39DrjAMGg4wEp9b0U="
-    # codebender compiler url (encrypted)
-    - secure: "hzL7akuLe+HCsi6G7Z1UliNR8ekzGlWv1cS/iweeXnxjISYU5ALrvpeOHNcfiC/xTZJsJXq+KYwZpVa/Ps7AVwfLgnUkQGD8OA7AmXbqgIv/xao24u4NNd+xAEB9LSr/eWexQhRJniE+JHgZ53yrAefJBIwmeD0YhvU1IdrzMdE="
+    # eratosthenes library management system url (encrypted) --> LIBRARY_URL
+    - secure: "DX1KR4VH1AwthSZ/6me6y8EB/xCf7kH+hXyacOiIwHmxPe7xR/+v7nht1Dlspco0nonv7hlF8yCilF2f3cIMHQlmyg9s1kuVZ4QtC8O9+ZkVQ6fDhhH7HKYNUKjhKO7eT5a+RD7YCXQYQSfDfJ35cWeK3vAast3zWK2pnmdKXhc="
+    # codebender compiler url (encrypted) --> COMPILER_URL
+    - secure: "QUYKE9qjXxeCWZPl+CQpIvj3J9Bz9aVu9jo1m+EDjaQ3gXwQ+kXTyZ68eDeLLCFq8s5IEcsNdE6X7wyBh+eu6rzEU5EwvGMqPdIpXxnhkzTbb8d2KRCScwkglrB/Dbh1Ovhq0+CdaSkLSQBQvOuxkqgGNf1Oophws6eG4iCIZKQ="’’
 
 before_script:
   - sudo chmod +x scripts/travis_install.sh

--- a/Symfony/src/Codebender/BuilderBundle/Controller/DefaultController.php
+++ b/Symfony/src/Codebender/BuilderBundle/Controller/DefaultController.php
@@ -179,7 +179,6 @@ class DefaultController extends Controller
             }
             $requestContent = ["type" => "fetch", "library" => $header];
             $data = $this->getLibraryInfo(json_encode($requestContent));
-            $data = json_decode($data, true);
 
             if ($data['success'] === false) {
                 $notFoundHeaders[] = $header . ".h";

--- a/Symfony/src/Codebender/BuilderBundle/Tests/Controller/DefaultControllerUnitTest.php
+++ b/Symfony/src/Codebender/BuilderBundle/Tests/Controller/DefaultControllerUnitTest.php
@@ -387,7 +387,7 @@ class DefaultControllerUnitTest extends \PHPUnit_Framework_TestCase
 
         $controller->expects($this->once())->method('getLibraryInfo')
             ->with('{"type":"fetch","library":"header"}')
-            ->willReturn(json_encode(['success' => true, 'files' => [['filename' => 'header.h', 'content' => '']]]));
+            ->willReturn(['success' => true, 'files' => [['filename' => 'header.h', 'content' => '']]]);
 
         $functionResponse = $function->invokeArgs($controller, [[], []]);
         $this->assertEquals(['header' => [['filename' => 'header.h', 'content' => '']]], $functionResponse['libraries']);
@@ -419,7 +419,7 @@ class DefaultControllerUnitTest extends \PHPUnit_Framework_TestCase
 
         $controller->expects($this->once())->method('getLibraryInfo')
             ->with('{"type":"fetch","library":"header"}')
-            ->willReturn(json_encode(['success' => false]));
+            ->willReturn(['success' => false]);
 
         $functionResponse = $function->invokeArgs($controller, [[], []]);
         $this->assertEquals([], $functionResponse['libraries']);

--- a/Symfony/src/Codebender/BuilderBundle/Tests/Controller/DefaultControllerUnitTest.php
+++ b/Symfony/src/Codebender/BuilderBundle/Tests/Controller/DefaultControllerUnitTest.php
@@ -182,7 +182,7 @@ class DefaultControllerUnitTest extends \PHPUnit_Framework_TestCase
 
         $functionResponse = $function->invoke($controller, ['files' => []]);
 
-        $this->assertContains('Failed to get compiler response', $functionResponse);
+        $this->assertContains('Failed to get compiler response', $functionResponse['message']);
     }
 
     public function testCompileFalseCompilationWithoutStepIncluded() {
@@ -217,7 +217,7 @@ class DefaultControllerUnitTest extends \PHPUnit_Framework_TestCase
         $functionResponse = $function->invoke($controller, ['files' => []]);
 
         $this->assertEquals(
-            '{"success":false,"message":"someError","step":"unknown","additionalCode":[]}',
+            ['success' => false, 'message' => 'someError', 'step' => 'unknown', 'additionalCode' => []],
             $functionResponse
         );
     }
@@ -254,13 +254,13 @@ class DefaultControllerUnitTest extends \PHPUnit_Framework_TestCase
 
         $functionResponse = $function->invoke($controller, ['files' => [], 'libraries' => []]);
 
-        $this->assertEquals('{"success":false,"message":"someError","step":5,"additionalCode":[]}', $functionResponse);
+        $this->assertEquals(['success' => false, 'message' => 'someError', 'step' => 5, 'additionalCode' => []], $functionResponse);
     }
 
     /*
      * Not much to test here
      */
-    public function testGetLibraryInfo() {
+    public function testGetLibraryInfoNormal() {
         $this->setUpController($controller, $container, $request, $apiHandler);
 
         // Override previous controller mock. More class member functions need to get mocked.
@@ -276,19 +276,53 @@ class DefaultControllerUnitTest extends \PHPUnit_Framework_TestCase
          */
         $function = $this->getMethod('getLibraryInfo');
 
-        $controller->expects($this->once())->method('get')->with('codebender_builder.handler')
+        $controller->expects($this->any())->method('get')->with('codebender_builder.handler')
             ->willReturn($apiHandler);
 
-        $container->expects($this->once())->method('getParameter')->with('library_manager')
+        $container->expects($this->any())->method('getParameter')->with('library_manager')
             ->will($this->returnValue('http://library/manager'));
 
+        // test normal library manager output
         $apiHandler->expects($this->once())->method('postRawData')
             ->with('http://library/manager', 'library data')
-            ->willReturn('Whatever');
+            ->willReturn('{"success":true}');
 
         $functionResponse = $function->invoke($controller, 'library data');
 
-        $this->assertEquals('Whatever', $functionResponse);
+        $this->assertEquals(['success' => true], $functionResponse);
+    }
+
+    public function testGetLibraryInfoInvalid()
+    {
+        $this->setUpController($controller, $container, $request, $apiHandler);
+
+        // Override previous controller mock. More class member functions need to get mocked.
+        $controller = $this->getMockBuilder('Codebender\BuilderBundle\Controller\DefaultController')
+            ->disableOriginalConstructor()
+            ->setMethods(['get', 'getRequest'])
+            ->getMock();
+
+        $controller->setContainer($container);
+
+        /*
+         * Use ReflectionMethod class to make compile protected function accessible from current context
+         */
+        $function = $this->getMethod('getLibraryInfo');
+
+        $controller->expects($this->any())->method('get')->with('codebender_builder.handler')
+            ->willReturn($apiHandler);
+
+        $container->expects($this->any())->method('getParameter')->with('library_manager')
+            ->will($this->returnValue('http://library/manager'));
+
+        // test invalid library manager output
+        $apiHandler->expects($this->once())->method('postRawData')
+            ->with('http://library/manager', 'library data')
+            ->willReturn('{not json : true');
+
+        $functionResponse = $function->invoke($controller, 'library data');
+
+        $this->assertEquals(['success' => false, 'message' => 'Cannot fetch library data'], $functionResponse);
     }
 
     public function testReturnProvidedAndFetchedLibrariesNoProvidedLibrariesNoProjectLibraries() {


### PR DESCRIPTION
### ChangeLog
- All builder responses made JsonResponse objects
- Handle invalid (not JSON) library manager responses
### Merge process

Nothing special, the changes will not affect the production setup
### QA

Not applicable, changes covered by Unit/Functional tests
